### PR TITLE
Update tree + cosmetic

### DIFF
--- a/js/elements/exec-results/exec-results.js
+++ b/js/elements/exec-results/exec-results.js
@@ -10,40 +10,34 @@ define(function(require) {
     var template = require('text!./template.html'),
         xhr = require('utils/xhr'),
         rivets = require('rivets'),
-        drawtree = require('./tree');
+        drawtree = require('./tree'),
+        xtag = require('x-tag');
 
     var exec_results = {
         onCreate: function() {
             document.addEventListener('exec', this.get_results);
-            this.xtag.inprogress = false;
-            rivets.bind(this, {vm: this.xtag});
+            drawtree.init(this);
         },
+        content: template,
+
         methods: {
             get_results: function(e) {
                 var that = this;
-                this.xtag.inprogress = true;
-                this.innerHTML = template;
+                this.toggleVisibility();
 
                 return xhr({method: 'GET', path: '/jobs/' + e.jid}, 700, 20)
-                .then(function(result) {
-                    that.xtag.inprogress = false;
-                    return result;
-                })
-                .get('return').get(0)
-                .then(this.render);
+                    .get('return').get(0)
+                    .then(function (result) {
+                        drawtree.updateTree(result);
+                        that.toggleVisibility();
+                    })
+                    .done();
             },
-            render: function(result) {
-                // this.innerHTML = JSON.stringify(result);
+            toggleVisibility: function() {
+                xtag.toggleClass(this.firstChild, 'hide');
 
-                // empty the node
-                while (this.firstChild) {
-                    this.removeChild(this.firstChild);
-                }
-
-                // fill the node with the output
-                drawtree(result, this);
-            },
-        },
+            }
+        }
     };
 
     return exec_results;

--- a/js/elements/exec-results/template.html
+++ b/js/elements/exec-results/template.html
@@ -1,4 +1,3 @@
-<div class="results">
-    <h4>Results</h4>
-    <p><i class="icon-spin icon-spinner"></i> Running ...</p>
+<div class="results hide">
+    <p><i class="icon-spinner icon-spin"></i> Running ...</p>
 </div>

--- a/js/elements/exec-results/tree.js
+++ b/js/elements/exec-results/tree.js
@@ -153,20 +153,22 @@ define(function(require) {
       return d._children ? "#3182bd" : d.children ? "#c6dbef" : "#fd8d3c";
     }
 
-    return function (result, el) {
-
+    return {
+        init: function(el) {
             vis = d3.select(el).append("svg:svg")
                 .attr("width", w)
                 .attr("height", h)
                 .append("svg:g")
                 .attr("transform", "translate(20,30)");
+        },
+        updateTree: function(result) {
             root = {
                 name: 'return',
                 children: d3.nest().entries(fmt(result)),
                 x0: 0,
                 y0: 0
             };
-
             update(root);
+        }
     }
 });

--- a/js/elements/exec-results/tree.js
+++ b/js/elements/exec-results/tree.js
@@ -68,6 +68,8 @@ define(function(require) {
           .attr("y", -barHeight / 2)
           .attr("height", barHeight)
           .attr("width", barWidth)
+          .attr("rx", 5)
+          .attr("ry", 5)
           .style("fill", color)
           .on("click", click);
 

--- a/js/elements/exec/exec.js
+++ b/js/elements/exec/exec.js
@@ -35,9 +35,9 @@ define(function(require) {
                     client: 'local',
                     tgt: this.xtag.tgt,
                     fun: this.xtag.fun,
-                    arg: this.xtag.arg ? this.xtag.arg.split(' ') : [],
+                    arg: this.xtag.arg ? this.xtag.arg.split(' ') : []
                 };
-            },
+            }
         },
 
         events: {
@@ -47,11 +47,13 @@ define(function(require) {
 
                 this.xtag.inprogress = true;
 
-                this.create_jid().then(function() {
-                    that.xtag.inprogress = false;
-                });
-            },
-        },
+                this.create_jid()
+                    .then(function() {
+                        that.xtag.inprogress = false;
+                    })
+                    .done();
+            }
+        }
     };
 
     return exec;

--- a/js/elements/minion-detail/minion-detail.js
+++ b/js/elements/minion-detail/minion-detail.js
@@ -11,7 +11,7 @@ modal with the details of that minion.
 define([
     'text!./template.html',
     'models/minions',
-    'rivets',
+    'rivets'
     ], function(template, minions, rivets) {
     'use strict';
 
@@ -24,19 +24,18 @@ define([
                 modal.innerHTML = template;
                 modal.setAttribute('overlay','');
                 modal.setAttribute('esc-hide','');
-
                 rivets.bind(modal,
-                    {minion: {id: 'stewart'}, vm: this.xtag});
+                    {minion: minions.getMinion(this.dataset.mid), vm: this.xtag});
 
                 frag.appendChild(modal);
                 document.body.appendChild(frag);
-            },
+            }
         },
         events: {
             click: function() {
                 this.detail();
-            },
-        },
+            }
+        }
     };
 
     return minion_detail;

--- a/js/elements/minion-detail/template.html
+++ b/js/elements/minion-detail/template.html
@@ -1,1 +1,6 @@
 <h1 data-text="minion.id"></h1>
+<ul class="unstyled">
+    <li>
+        OS: <span data-text="minion.os"></span>
+    </li>
+</ul>

--- a/js/elements/minion-list/minion-list.js
+++ b/js/elements/minion-list/minion-list.js
@@ -9,7 +9,7 @@ define([
     'text!./template.html',
     'models/minions',
     'rivets',
-    'underscore',
+    'underscore'
     ], function(template, minions, rivets, _) {
     'use strict';
 
@@ -23,7 +23,7 @@ define([
                 rivets.bind(that,
                     {minions: {minions: _.values(result)}, vm: that.xtag});
             });
-        },
+        }
     };
 
     return minion_list;

--- a/js/mixins/exec.js
+++ b/js/mixins/exec.js
@@ -27,15 +27,13 @@ define(function(require) {
             create_jid: function() {
                 var that = this;
 
-                var request = xhr({method: 'POST', path: '/minions',
-                    data: [this.lowstate]})
-                .get(0).get('return').then(function(result) {
-                    xtag.fireEvent(that, 'exec', {jid: result.jid});
-                });
-
-                return request;
-            },
-        },
+                return xhr({method: 'POST', path: '/minions', data: [this.lowstate]})
+                    .get(0).get('return')
+                    .then(function(result) {
+                        xtag.fireEvent(that, 'exec', {jid: result.jid});
+                    })
+            }
+        }
     };
 
     return exec;

--- a/js/models/minions.js
+++ b/js/models/minions.js
@@ -45,6 +45,14 @@ define(function(require) {
         },
 
         /**
+         Return the cached minion by id
+         @return {Object}
+         **/
+        getMinion: function(id) {
+           return this._result[id];
+        },
+
+        /**
         Returns the cached copy of results or queries the API for new results
         @returns {Promise}
         **/
@@ -53,7 +61,7 @@ define(function(require) {
                 return Q.fcall(function(){ return this._result; }.bind(this));
             }
             return this.sync();
-        },
+        }
     };
 
     return minions;

--- a/tmpl/exec.html
+++ b/tmpl/exec.html
@@ -13,7 +13,7 @@
             <h2 class="nav-header">Minions</h2>
             <x-minion-filter></x-minion-filter>
             <x-minion-list>
-                <i class="icon-spin icon-spinner"></i>
+                <i class="icon-spinner icon-spin"></i>
                 Loading minions ...
             </x-minion-list>
         </div>


### PR DESCRIPTION
Hi,

Could you review these two commits ?

In the first one, I propose to update the tree instead of regenerate a new one whenever we submit a command.

The second one is cosmetic.

I would like to issue a third pull request. I am not convinced that managing a "progress" state on the node is the way to go. I would simply remove the spinning attribute when it is necessary in the line of my first commit.

I believe we have two different usages here that might be nicely refactor in a x-tag mixin. The first one is to show/hide the "icon-spinner" and the other one is to spin on/off the "icon-spinner".

As a note, I am not totally convinced by x-tags. I have found the doc quite awful and [the component code](https://github.com/mozilla/x-tag-elements/tree/xtag-v0.0.22) not so pretty.

It would be nice as well to establish some convention because the "this/that" ugly trick is confusing enough ;-) So in this pull request I took the liberty to favor "inline then" with "this/that" instead of defining another method (the main motivation is not to expose these callbacks too much).

Let me know what you think. I am not totally clear on what's best at the moment ...

You might be right thinking that wiping out the children nodes is actually more flexible.

 I look forward for your feedback. Thanks.
