### PR TITLE
Sync minion-list every 30s

### DIFF
--- a/js/elements/minion-detail/minion-detail.js
+++ b/js/elements/minion-detail/minion-detail.js
@@ -25,7 +25,7 @@ define([
                 modal.setAttribute('overlay','');
                 modal.setAttribute('esc-hide','');
                 rivets.bind(modal,
-                    {minion: minions.getMinion(this.dataset.mid), vm: this.xtag});
+                    {minion: minions.get_minion(this.dataset.mid), vm: this.xtag});
 
                 frag.appendChild(modal);
                 document.body.appendChild(frag);
@@ -35,7 +35,7 @@ define([
             click: function() {
                 this.detail();
             }
-        }
+        },
     };
 
     return minion_detail;

--- a/js/elements/minion-list/minion-list.js
+++ b/js/elements/minion-list/minion-list.js
@@ -16,13 +16,14 @@ define([
     var minion_list = {
         onCreate: function(){
             var that = this;
+            // Sync the list of minions every 30s
+            window.setInterval(function() {minions.sync(); },30000);
 
-            minions.get_result().then(function(result) {
-                that.innerHTML = template;
-
-                rivets.bind(that,
-                    {minions: {minions: _.values(result)}, vm: that.xtag});
-            });
+            minions.get_result()
+                .then(function(result) {
+                    that.innerHTML = template;
+                    rivets.bind(that,{minions: minions, vm: that.xtag});
+                }).done();
         }
     };
 

--- a/js/elements/minion-list/template.html
+++ b/js/elements/minion-list/template.html
@@ -1,3 +1,3 @@
-<x-minion-detail data-each-minion="minions.minions" data-data-mid="minion:id">
+<x-minion-detail data-each-minion="minions:get_minions < .sync_toggle" data-data-mid="minion:id">
     <i class="icon-circle running"></i> <span data-text="minion.id"></span>
 </x-minion-detail>


### PR DESCRIPTION
Refresh the list of active minions displayed to the user (rivets bindings in action !)

Some comments:
- not sure why you wanted to append the list of _result.
- the timeout number settings (30 sec) needs to be put in a central configuration somewhere.
- works in Firefox and Chrome (Chrome does not work if I move the "setInterval" line into saltui.js (anyway it was probably not the right place. Maybe because Chrome requires the dom to be in a ready state ?).

The idea is to merge a list of all minions (from pillars ?) with the list of active responding minions.

I have used the python convention for naming functions. Is this ok or do you plan to revert to a more conventional js style ?

As a note (nothing to do with this pull request) I have realized nothing works with IE 9. Apparently dataset is not supported. 
