### PR TITLE
Use proper url for less to avoid redirect issues.

### DIFF
--- a/js/lib/libs.txt
+++ b/js/lib/libs.txt
@@ -34,5 +34,5 @@
 --url "https://raw.github.com/PuerkitoBio/advice/51d2124/lib/advice.js"
 -O
 
---url "https://raw.github.com/cloudhead/less.js/master/dist/less-1.3.3.js"
+--url "https://raw.github.com/less/less.js/master/dist/less-1.3.3.js"
 -o "less.js"


### PR DESCRIPTION
This resolves the issue of `make` generating `js/lib/less.js` that only contains `<html><body>You are being <a href="https://raw.github.com/less/less.js/master/dist/less-1.3.3.js">redirected</a>.</body></html>`
